### PR TITLE
Added basic support for the new gpt-3.5-turbo model.

### DIFF
--- a/lua/_ai/commands.lua
+++ b/lua/_ai/commands.lua
@@ -70,6 +70,9 @@ function M.ai (args)
             vim.api.nvim_err_writeln("ai.vim: " .. err)
         else
             local text = result.choices[1].text
+            if result.model and string.find(result.model, "gpt-3.5-turbo", 1, true) then
+                text = result.choices[1].message.content
+            end
             local lines = {}
             for line in text:gmatch("([^\n]*)\n?") do
                 table.insert(lines, line)

--- a/lua/_ai/openai.lua
+++ b/lua/_ai/openai.lua
@@ -55,6 +55,17 @@ end
 ---@param body table
 ---@param on_result fun(err: string?, output: unknown?): nil
 function M.call (endpoint, body, on_result)
+    if body.model == "gpt-3.5-turbo" then
+        endpoint = "chat/completions"
+        body.messages = {
+            [1] = {
+                role = "user",
+                content = body.prompt,
+            },
+        }
+        body.prompt = nil
+        body.suffix = nil
+    end
     local api_key = os.getenv("OPENAI_API_KEY")
     if not api_key then
         on_result("$OPENAI_API_KEY environment variable must be set")


### PR DESCRIPTION
OpenAI has announced the launch of a new model, gpt-3.5-turbo, which is 10 times cheaper than their existing GPT-3.5 models(from https://openai.com/blog/introducing-chatgpt-and-whisper-apis). This PR added basic support for the new model.