### PR TITLE
Fix a bug that occurs when a multi-byte character under the cursor.

### DIFF
--- a/lua/_ai/commands.lua
+++ b/lua/_ai/commands.lua
@@ -23,13 +23,15 @@ function M.ai (args)
 
         local end_pos = vim.api.nvim_buf_get_mark(buffer, ">")
         end_row = end_pos[1] - 1
-        end_col = end_pos[2] + 1
+        local line = vim.fn.getline(end_pos[1])
+        end_col = vim.fn.byteidx(line, vim.fn.charcol("'>"))
 
     else
         -- Use the cursor position
         local start_pos = vim.api.nvim_win_get_cursor(0)
         start_row = start_pos[1] - 1
-        start_col = start_pos[2] + 1
+        local line = vim.fn.getline(start_pos[1])
+        start_col = vim.fn.byteidx(line, vim.fn.charcol("."))
         end_row = start_row
         end_col = start_col
     end


### PR DESCRIPTION
The bug can be reproduced by pressing `<CTRL-A>` when the cursor is positioned on a multi-byte character. For instance, if you input "你好" and then press `<CTRL-A>`, the request will inevitably fail.

The reason for this issue is that the `vim.api.nvim_win_get_cursor(0)` or `vim.api.nvim_buf_get_mark(1, "<")` functions return the column number of the cursor without including the character under it. To include it, one needs to add one to the column number. This approach works well for single-byte characters but not for multi-byte ones, in which case adding one to the column number in order to include an additional byte results in an invalid encoding byte sequence which causes requests to fail. However, this bug has been resolved now.