### PR TITLE
Fix OPENAI_KEY_API typo in the help file.

### DIFF
--- a/doc/ai.txt
+++ b/doc/ai.txt
@@ -12,7 +12,7 @@ You'll need an OpenAI account and to generate an API key here:
 
         https://beta.openai.com/account/api-keys
 
-Then set the `$OPEN_AI_API_KEY` environment variable, for example, by adding
+Then set the `$OPENAI_API_KEY` environment variable, for example, by adding
 it to your `~/.profile`:
 
         `export OPENAI_API_KEY="sk-abcdefghijklmnopqrstuvwxyz1234567890"`


### PR DESCRIPTION
This occurence of OPENAI_API_KEY has an extra underscore which is not present in either the code or the rest of the help.